### PR TITLE
define_method is private, gotta send it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ before_install:
 script:
   - 'bundle exec rake ci'
 rvm:
-  - 2.5
+  - 2.3.4
+  - 2.4.1

--- a/lib/generators/docker/stack/service.rb
+++ b/lib/generators/docker/stack/service.rb
@@ -13,7 +13,7 @@ module Docker
 
         base.class_option :env, type: :string, default: 'development,test'
 
-        base.define_method :add_service do
+        base.send(:define_method, :add_service) do
           options[:env].split(/,/).each do |env|
             @env = env
             add_service_for_environment


### PR DESCRIPTION
i kept getting this error while running the service generators: 
```
[WARNING] Could not load generator "generators/docker/stack/service/fedora_generator". Error: private method `define_method' called for Docker::Stack::Service::FedoraGenerator:Class
Did you mean?  redefine_method.
```

so i fixed it!!